### PR TITLE
Logging improvements

### DIFF
--- a/slackclient/client.py
+++ b/slackclient/client.py
@@ -8,7 +8,6 @@ import time
 from .server import Server
 from .exceptions import ParseResponseError, TokenRefreshError
 
-
 LOG = logging.getLogger(__name__)
 
 
@@ -139,8 +138,9 @@ class SlackClient(object):
         try:
             self.server.rtm_connect(use_rtm_start=with_team_state, **kwargs)
             return self.server.connected
-        except Exception:
-            LOG.warn("Failed RTM connect", exc_info=True)
+        except Exception as e:
+            LOG.warn("Failed RTM connect")
+            LOG.exception(e)
             return False
 
     def api_call(self, method, timeout=None, **kwargs):


### PR DESCRIPTION
###  Summary

Adds logging for a few exception cases, as desired in https://github.com/slackapi/python-slackclient/pull/246. The main difference is that this PR applies more recent best practices of using a namespaced logger according to the module name.

This PR also refactors the existing logging in `client.py` (applied in https://github.com/slackapi/python-slackclient/pull/309) to use the `Logger.exception()` instead of `Logger.warn()`, since it will print a more standard representation of the exception with its call stack (traceback). The warning level log was kept for consistency with previous logging.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/python-slackclient/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).